### PR TITLE
インクリメンタルサーチの実装

### DIFF
--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -1,0 +1,5 @@
+$(function(){
+  $("#user-search-field").on("keyup", function(){
+    var input = $("#user-search-field").val();
+  });
+});

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -1,5 +1,43 @@
 $(function(){
+  var search_list = $("#user-search-result");
+  function appendUser(user){
+    var html = `<div class="chat-group-user clearfix">
+                  <p class="chat-group-user__name">${ user.name }</p>
+                  <a class="user-search-add chat-group-user__btn chat-group-user__btn--add" data-user-id=${ user.id } data-user-name=${ user.name }>追加</a>
+                </div>`
+    search_list.append(html);
+  }
+
+  function appendNoUser(user){
+    var html = `<div class="chat-group-user cleafix">
+                  <p class="chat-group-user__name">${ user }</p>
+                </div>`
+    search_list.append(html);
+  }
+
   $("#user-search-field").on("keyup", function(){
-    var input = $("#user-search-field").val();
+    var input = $(this).val();
+
+    $.ajax({
+      type: 'GET',
+      url: '/users',
+      data: { keyword: input },
+      dataType: 'json'
+    })
+    .done(function(users){
+      $("#user-search-result").empty();
+      if (users.length !== 0){
+        users.forEach(function(user){
+          appendUser(user);
+          console.log();
+        });
+      }
+      else {
+        appendNoUser("一致するユーザーはいません");
+      }
+    })
+    .fail(function(){
+      alert('ユーザー検索に失敗しました');
+    })
   });
 });

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -1,18 +1,29 @@
 $(function(){
-  var search_list = $("#user-search-result");
+  var searchList = $("#user-search-result");
+  var chatGroupMembers = $("#chat-group-users");
+
   function appendUser(user){
     var html = `<div class="chat-group-user clearfix">
                   <p class="chat-group-user__name">${ user.name }</p>
                   <a class="user-search-add chat-group-user__btn chat-group-user__btn--add" data-user-id=${ user.id } data-user-name=${ user.name }>追加</a>
                 </div>`
-    search_list.append(html);
+    searchList.append(html);
   }
 
   function appendNoUser(user){
     var html = `<div class="chat-group-user cleafix">
                   <p class="chat-group-user__name">${ user }</p>
                 </div>`
-    search_list.append(html);
+    searchList.append(html);
+  }
+
+  function appendMember(id, name){
+    var html = `<div class='chat-group-user clearfix js-chat-member' id='chat-group-user-${ id }'>
+                  <input name='group[user_ids][]' type='hidden' value=${ id }>
+                  <p class='chat-group-user__name'>${ name }</p>
+                  <a class='user-search-remove chat-group-user__btn chat-group-user__btn--remove js-remove-btn'>削除</a>
+                </div>`
+    chatGroupMembers.append(html);
   }
 
   $("#user-search-field").on("keyup", function(){
@@ -29,7 +40,6 @@ $(function(){
       if (users.length !== 0){
         users.forEach(function(user){
           appendUser(user);
-          console.log();
         });
       }
       else {
@@ -39,5 +49,16 @@ $(function(){
     .fail(function(){
       alert('ユーザー検索に失敗しました');
     })
+  });
+
+  searchList.on("click", '.user-search-add', function(){
+    var id = $(this).data('user-id');
+    var name = $(this).data('user-name');
+    appendMember(id, name);
+    searchList.empty();
+  });
+
+  chatGroupMembers.on("click", '.user-search-remove', function(){
+    $(this).parent().remove();
   });
 });

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,12 @@
 class UsersController < ApplicationController
+  def index
+    @users = User.where('name LIKE(?)', "%#{params[:keyword]}%").where.not(id: current_user.id)
+    respond_to do |format|
+      format.html
+      format.json
+    end
+  end
+
   def edit
     @user = User.find(params[:id])
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,6 @@ class UsersController < ApplicationController
   def index
     @users = User.where('name LIKE(?)', "%#{params[:keyword]}%").where.not(id: current_user.id)
     respond_to do |format|
-      format.html
       format.json
     end
   end

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -17,7 +17,7 @@
 
     .chat-group-form__field--right
       .chat-group-form__search.clearfix
-        %input#user-search-field.chat-group-form__input{ placeholder: '追加したいユーザー名を入力してください'}
+        %input#user-search-field.chat-group-form__input{ placeholder: '追加したいユーザー名を入力してください', type: "text"}
       #user-search-result
 
   .chat-group-form__field.clearfix
@@ -26,9 +26,6 @@
 
     .chat-group-form__field--right
       #chat-group-users
-      #chat-group-user-22.chat-group-user.clearfix
-      %input{ name: "chat_group[user_ids][]", type: "hidden", value: "22" }
-      %p.chat-group-user__name seo_kyohei
 
   .chat-group-form__field.clearfix
     .chat-group-form__field--left

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -10,32 +10,26 @@
       = f.label :name, class: 'chat-group-form__label'
     .chat-group-form__field--right
       = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
-  .chat-group-form__field.clearfix
-    / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
-    /
-      <div class='chat-group-form__field--left'>
-      <label class="chat-group-form__label" for="chat_group_チャットメンバーを追加">チャットメンバーを追加</label>
-      </div>
-      <div class='chat-group-form__field--right'>
-      <div class='chat-group-form__search clearfix'>
-      <input class='chat-group-form__input' id='user-search-field' placeholder='追加したいユーザー名を入力してください' type='text'>
-      </div>
-      <div id='user-search-result'></div>
-      </div>
+
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
-      %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
+      = f.label "チャットメンバーを追加", class: 'chat-group-form__label', for:"chat_group_チャットメンバーを追加"
+
     .chat-group-form__field--right
-      / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-      = f.collection_check_boxes :user_ids, User.all, :id, :name
-      / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
-      /
-        <div id='chat-group-users'>
-        <div class='chat-group-user clearfix' id='chat-group-user-22'>
-        <input name='chat_group[user_ids][]' type='hidden' value='22'>
-        <p class='chat-group-user__name'>seo_kyohei</p>
-        </div>
-        </div>
+      .chat-group-form__search.clearfix
+        %input#user-search-field.chat-group-form__input{ placeholder: '追加したいユーザー名を入力してください'}
+      #user-search-result
+
+  .chat-group-form__field.clearfix
+    .chat-group-form__field--left
+      %label.chat-group-form__label{ for: "chat_group_チャットメンバー"} チャットメンバー
+
+    .chat-group-form__field--right
+      #chat-group-users
+      #chat-group-user-22.chat-group-user.clearfix
+      %input{ name: "chat_group[user_ids][]", type: "hidden", value: "22" }
+      %p.chat-group-user__name seo_kyohei
+
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
     .chat-group-form__field--right

--- a/app/views/users/index.json.jbuilder
+++ b/app/views/users/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @users do |user|
+  json.id user.id
+  json.name user.name
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root 'groups#index'
-  resources :users, only: [:edit, :update]
+  resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
   end


### PR DESCRIPTION
# What
チャットグループの新規作成ならびに編集の際、
メンバーの追加・削除をcollection_checkboxesにて行っていたが、
これに代わり、インクリメンタルサーチでメンバーを表示させ追加・削除を行えるよう実装する。

# Why
- ユーザが増えてきた時に備える
- ひいてはそれがUX向上に繋がるため